### PR TITLE
Feature/card as payment type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -240,3 +240,4 @@ ModelManifest.xml
 
 # FAKE - F# Make
 .fake/
+nuget.exe

--- a/src/CeriQ.Svea.Checkout/CeriQ.Svea.Checkout.nuspec
+++ b/src/CeriQ.Svea.Checkout/CeriQ.Svea.Checkout.nuspec
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>CeriQ.Svea.Checkout</id>
+    <version>1.0.0</version>
+    <title>CeriQ Svea Checkout Client</title>
+    <authors>Eric Johansson</authors>
+    <owners>Eric Johansson</owners>
+    <licenseUrl>https://github.com/CeriQ/CeriQ.Svea.Checkout/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/CeriQ/CeriQ.Svea.Checkout</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Client for Svea Ekonomi checkout solution. Simplifies REST calls with securitytokens to simple class function calls.</description>
+    <releaseNotes>First release</releaseNotes>
+    <copyright>Copyright 2018</copyright>
+    <tags>Svea Checkout Payment CeriQ APIClient Client API</tags>
+  </metadata>
+</package>

--- a/src/CeriQ.Svea.Checkout/CeriQ.Svea.Checkout.nuspec
+++ b/src/CeriQ.Svea.Checkout/CeriQ.Svea.Checkout.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>CeriQ.Svea.Checkout</id>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <title>CeriQ Svea Checkout Client</title>
     <authors>Eric Johansson</authors>
     <owners>Eric Johansson</owners>

--- a/src/CeriQ.Svea.Checkout/Properties/AssemblyInfo.cs
+++ b/src/CeriQ.Svea.Checkout/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.1.0")]
+[assembly: AssemblyFileVersion("1.0.1.0")]

--- a/src/CeriQ.Svea.Checkout/Types/PaymentType.cs
+++ b/src/CeriQ.Svea.Checkout/Types/PaymentType.cs
@@ -12,6 +12,7 @@
         SVEACARDPAY,
         SVEACARDPAY_PF,
         ACCOUNTCREDIT,
+        CARD,
         // DirektBank types
         BANKAXESS,
         DBAKTIAFI,


### PR DESCRIPTION
Adding card as payment type. This paymenttype value is not documented in Sveas documentation but started showing up today(180329).